### PR TITLE
Simplify the interactive_xy_plot interface, and make it work with specified y-scale

### DIFF
--- a/biocircuits/viz.py
+++ b/biocircuits/viz.py
@@ -36,9 +36,10 @@ def interactive_xy_plot(base_plot, callback, slider_params, toggle_params,
         A function that is executed to update the `ColumnDataSource` of
         the interactive plot whenever a slider or toggle are updated.
         It must have a call signature
-        `callback(source, x_range, sliders, toggles, *extra_args)`.
-        Here, `source` is a `ColumnDataSource`, and `x_range` is the
-        x_range of the plot. `sliders`, `toggles`, and `extra_args` are
+        `callback(source, x_range, y_range, sliders, toggles, *extra_args)`.
+        Here, `source` is a `ColumnDataSource`, `x_range` is the
+        x_range of the plot, and `y_range` is the y_range of the plot. 
+        `sliders`, `toggles`, and `extra_args` are
         as defined above.
     slider_params : tuple of objects
         Each object in the tuple is an instance of a class that has the
@@ -108,6 +109,9 @@ def interactive_xy_plot(base_plot, callback, slider_params, toggle_params,
         p.x_range.on_change('end', _callback)
         p.y_range.on_change('start', _callback)
         p.y_range.on_change('end', _callback)
+
+        # Call the callback once, to kick things off
+        callback(source, p.x_range, p.y_range, sliders, toggles, *extra_args)
 
         # Add the plot to the app
         widgets = bokeh.layouts.widgetbox(*sliders, *toggles)


### PR DESCRIPTION
The old interface is to have the user create a plot function and a callback function. In the callback function, the plot is created without x/y ranges, but is initialized in interactive_xy_plot to use DataRange1d's. Then, the user is responsible for the first call to the callback, which fills the data source.

This fails under certain circumstances when the y range is specified in addition to the x-range (the docstring was also inaccurate regarding use of the y-axis). I was plotting (see Piazza code) a vector field using "segment", which exceeded the given y-range. Because the y-range is overridden to be flexible with respect the data, you get infinite re-scaling when the plot is generated, without any user input.

![bokeh_plotting](https://user-images.githubusercontent.com/1854223/56099532-14140200-5ec3-11e9-87a1-4fe327cc26bf.gif)

This change is tested against that test case, and is partially tested with HW1 solutions and some of the other test cases. If just the x-axis is specified in the bokeh.plotting.figure constructor, the y-axis is still setup to be auto-ranged by the data. I didn't rebuild the Python module, just copy and pasted the code into Jupyter and renamed the interactive_xy_plot to something local to test, so that would also be good to check.

The new interface, using an example from the lecture notes, would be just directly specifying the ranges in the bokeh.plotting.figure constructor.

I also don't have a fantastic grasp on Bokeh yet, so take this PR with a grain of salt.

```
slider_params = (biocircuits.AttributeContainer(title='k', start=0.1, 
                                                end=10, value=1, step=0.05),
                 biocircuits.AttributeContainer(title='n', start=1, 
                                                end=10, value=1, step=0.1))

extra_args = (400,)


def hill_callback(source, x_range, y_range, sliders, toggles, n_points):
    # Set up x values, keeping minimum at zero
    x = np.linspace(0, x_range.end, n_points)
    
    # Pull out slider values
    k = sliders[0].value
    n = sliders[1].value
    
    # Compute Hill function
    source.data['x'] = x
    source.data['y'] = (x/k)**n / (1 + (x/k)**n)


def hill_plot(callback, sliders, toggles, extra_args):
    # Set up plot
    p = bokeh.plotting.figure(plot_width=500,
                              plot_height=300,
                              x_axis_label='x',
                              y_axis_label='f(x;k,n)',
                    # -- CHANGE, just specify axis limits here
                              x_range=bokeh.models.Range1d(0,10))

    # Set up empty data source
    source = bokeh.models.ColumnDataSource()

    # Populate glyphs
    p.line('x', 'y', source=source, line_width=2)

    # ---CHANGE-> NO LONGER NEED THIS CALL
    #callback(source, bokeh.models.Range1d(0, 10), None, 
    #        sliders, toggles, *extra_args)

    return p, source

hill_app = biocircuits.interactive_xy_plot(hill_plot, hill_callback, 
                                           slider_params, (), extra_args)
bokeh.io.show(hill_app, notebook_url=notebook_url)
```



